### PR TITLE
feat: Implement parsing

### DIFF
--- a/.cursor/rules/tree-sitter-debugging.mdc
+++ b/.cursor/rules/tree-sitter-debugging.mdc
@@ -1,0 +1,7 @@
+---
+description: Debugging tree-sitter nodes
+globs: *.rs
+---
+
+When processing a new kind of tree-sitter node or troubleshooting its processing, temporarily print the output of `daipendency_testing::debug_node(...)` from the `daipendency-testing` crate to learn the structure of such a node.
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "daipendency-extractor"
-version = "1.0.8"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add06e834352b489f67c1273ea316377ef8bf628cb658cda9e09662d6a6e40c"
+checksum = "d11db66dde6e57e890bffbe3d38ef5d6025a18da7488208d99e4b8ad68d059a0"
 dependencies = [
  "cc",
  "thiserror",
@@ -66,13 +66,19 @@ dependencies = [
 
 [[package]]
 name = "daipendency-testing"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ecd58ee8682065fdc4bc2d3476a7bb485df53ac51d83ba00dc9dbd8b79d54b8"
+checksum = "99933717302953bd1d2545b27aad45c89f52bbae0c07069f69e32f37136a89d5"
 dependencies = [
  "tempfile",
  "tree-sitter",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -100,6 +106,22 @@ dependencies = [
  "libc",
  "wasi",
  "windows-targets",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "indexmap"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -233,6 +255,7 @@ version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -298,13 +321,14 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.7"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+checksum = "5168a515fe492af54c5cc8800ff8c840be09fa5168de45838afaecd3e008bce4"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,11 +65,12 @@ dependencies = [
 
 [[package]]
 name = "daipendency-testing"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80a93cda5b824f4396736661020dece75e1965f5835c96461deed8c61c71577"
+checksum = "0ecd58ee8682065fdc4bc2d3476a7bb485df53ac51d83ba00dc9dbd8b79d54b8"
 dependencies = [
  "tempfile",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "daipendency-testing",
  "serde",
  "serde_json",
+ "streaming-iterator",
  "tree-sitter",
  "tree-sitter-typescript",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ tree-sitter-typescript = "0.23.2"
 
 [dev-dependencies]
 assertables = "9.5.0"
-daipendency-testing = "1.1.0"
+daipendency-testing = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ authors = ["Gus Narea"]
 daipendency-extractor = "1.0.8"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
+streaming-iterator = "0.1.9"
 tree-sitter = "^0.24.6"
 tree-sitter-typescript = "0.23.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ license = "MIT"
 authors = ["Gus Narea"]
 
 [dependencies]
-daipendency-extractor = "1.0.8"
+daipendency-extractor = "1.1.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 streaming-iterator = "0.1.9"
-tree-sitter = "^0.24.6"
+tree-sitter = "^0.25.2"
 tree-sitter-typescript = "0.23.2"
 
 [dev-dependencies]
 assertables = "9.5.0"
-daipendency-testing = "1.2.0"
+daipendency-testing = "1.2.1"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # daipendency-extractor-typescript
-Daipendency extractor for TypeScript libraries
+
+Daipendency extractor for TypeScript declarations.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,270 @@
+use daipendency_extractor::{ExtractionError, LibraryMetadata, Namespace, Symbol};
+use tree_sitter::{Node, Parser};
+
+pub fn extract_public_api(
+    library_metadata: &LibraryMetadata,
+    parser: &mut Parser,
+) -> Result<Vec<Namespace>, ExtractionError> {
+    let source_code =
+        std::fs::read_to_string(&library_metadata.entry_point).map_err(ExtractionError::Io)?;
+
+    let tree = parser
+        .parse(&source_code, None)
+        .ok_or_else(|| ExtractionError::Malformed("Failed to parse source".to_string()))?;
+
+    let mut namespaces = vec![Namespace {
+        name: library_metadata.name.clone(),
+        symbols: Vec::new(),
+        doc_comment: None,
+    }];
+
+    process_node(tree.root_node(), &source_code, &mut namespaces)?;
+
+    Ok(namespaces)
+}
+
+fn process_node(
+    node: Node,
+    source_code: &str,
+    namespaces: &mut Vec<Namespace>,
+) -> Result<(), ExtractionError> {
+    if node.kind() == "export_statement" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            match child.kind() {
+                "enum_declaration"
+                | "interface_declaration"
+                | "class_declaration"
+                | "function_declaration"
+                | "type_alias_declaration" => {
+                    let name = get_declaration_name(&child, source_code).ok_or_else(|| {
+                        ExtractionError::Malformed("Declaration without name".to_string())
+                    })?;
+                    namespaces[0].symbols.push(Symbol {
+                        name,
+                        source_code: get_node_text(node, source_code),
+                    });
+                }
+                "lexical_declaration" => {
+                    let mut var_cursor = child.walk();
+                    for var_child in child.children(&mut var_cursor) {
+                        if var_child.kind() == "variable_declarator" {
+                            let name = get_declaration_name(&var_child, source_code)
+                                .ok_or_else(|| {
+                                    ExtractionError::Malformed(
+                                        "Variable without name".to_string(),
+                                    )
+                                })?;
+                            namespaces[0].symbols.push(Symbol {
+                                name,
+                                source_code: get_node_text(node, source_code),
+                            });
+                        }
+                    }
+                }
+                "internal_module" => {
+                    let name = get_declaration_name(&child, source_code).ok_or_else(|| {
+                        ExtractionError::Malformed("Namespace without name".to_string())
+                    })?;
+                    namespaces.push(Namespace {
+                        name,
+                        symbols: Vec::new(),
+                        doc_comment: None,
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        process_node(child, source_code, namespaces)?;
+    }
+
+    Ok(())
+}
+
+fn get_declaration_name(node: &Node, source_code: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "identifier" | "type_identifier" => {
+                return Some(get_node_text(child, source_code));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn get_node_text(node: Node, source_code: &str) -> String {
+    source_code[node.start_byte()..node.end_byte()].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TypeScriptExtractor;
+    use daipendency_extractor::Extractor;
+    use daipendency_testing::{debug_node, tempdir::TempDir};
+    use tree_sitter::Parser;
+
+    fn make_parser() -> Parser {
+        let mut parser = Parser::new();
+        let language = TypeScriptExtractor.get_parser_language();
+        parser.set_language(&language).unwrap();
+        parser
+    }
+
+    fn setup_test_dir(content: &str) -> (TempDir, LibraryMetadata) {
+        let temp_dir = TempDir::new();
+        temp_dir
+            .create_file(
+                "package.json",
+                r#"{"name": "test-pkg", "version": "1.0.0", "types": "index.d.ts"}"#,
+            )
+            .unwrap();
+        temp_dir.create_file("index.d.ts", content).unwrap();
+
+        let library_metadata = LibraryMetadata {
+            name: "test-pkg".to_string(),
+            version: Some("1.0.0".to_string()),
+            documentation: String::new(),
+            entry_point: temp_dir.path.join("index.d.ts"),
+        };
+
+        (temp_dir, library_metadata)
+    }
+
+    #[test]
+    fn exported_interface() {
+        let (_temp_dir, library_metadata) =
+            setup_test_dir("export interface Person { name: string; age: number; }");
+        let mut parser = make_parser();
+
+        let tree = parser
+            .parse(
+                "export interface Person { name: string; age: number; }",
+                None,
+            )
+            .unwrap();
+        println!(
+            "Node structure:\n{}",
+            debug_node(
+                &tree.root_node(),
+                "export interface Person { name: string; age: number; }"
+            )
+        );
+
+        let namespaces = extract_public_api(&library_metadata, &mut parser).unwrap();
+
+        assert_eq!(namespaces.len(), 1);
+        assert_eq!(namespaces[0].name, "test-pkg");
+        assert_eq!(namespaces[0].symbols.len(), 1);
+        assert_eq!(namespaces[0].symbols[0].name, "Person");
+        assert_eq!(
+            namespaces[0].symbols[0].source_code,
+            "export interface Person { name: string; age: number; }"
+        );
+    }
+
+    #[test]
+    fn exported_enum() {
+        let (_temp_dir, library_metadata) =
+            setup_test_dir("export enum Status { Active = 'active', Inactive = 'inactive' }");
+        let mut parser = make_parser();
+
+        let namespaces = extract_public_api(&library_metadata, &mut parser).unwrap();
+
+        assert_eq!(namespaces.len(), 1);
+        assert_eq!(namespaces[0].symbols.len(), 1);
+        assert_eq!(namespaces[0].symbols[0].name, "Status");
+    }
+
+    #[test]
+    fn exported_class() {
+        let (_temp_dir, library_metadata) =
+            setup_test_dir("export class User { constructor(public name: string) {} }");
+        let mut parser = make_parser();
+
+        let namespaces = extract_public_api(&library_metadata, &mut parser).unwrap();
+
+        assert_eq!(namespaces.len(), 1);
+        assert_eq!(namespaces[0].symbols.len(), 1);
+        assert_eq!(namespaces[0].symbols[0].name, "User");
+    }
+
+    #[test]
+    fn exported_function() {
+        let (_temp_dir, library_metadata) = setup_test_dir(
+            "export function greet(name: string): string { return `Hello ${name}`; }",
+        );
+        let mut parser = make_parser();
+
+        let namespaces = extract_public_api(&library_metadata, &mut parser).unwrap();
+
+        assert_eq!(namespaces.len(), 1);
+        assert_eq!(namespaces[0].symbols.len(), 1);
+        assert_eq!(namespaces[0].symbols[0].name, "greet");
+    }
+
+    #[test]
+    fn exported_type_alias() {
+        let (_temp_dir, library_metadata) = setup_test_dir("export type UserId = string;");
+        let mut parser = make_parser();
+
+        let namespaces = extract_public_api(&library_metadata, &mut parser).unwrap();
+
+        assert_eq!(namespaces.len(), 1);
+        assert_eq!(namespaces[0].symbols.len(), 1);
+        assert_eq!(namespaces[0].symbols[0].name, "UserId");
+    }
+
+    #[test]
+    fn exported_namespace() {
+        let (_temp_dir, library_metadata) =
+            setup_test_dir("export namespace Utils { export function helper(): void {} }");
+        let mut parser = make_parser();
+
+        let tree = parser
+            .parse(
+                "export namespace Utils { export function helper(): void {} }",
+                None,
+            )
+            .unwrap();
+        println!(
+            "Namespace node structure:\n{}",
+            debug_node(
+                &tree.root_node(),
+                "export namespace Utils { export function helper(): void {} }"
+            )
+        );
+
+        let namespaces = extract_public_api(&library_metadata, &mut parser).unwrap();
+
+        assert_eq!(namespaces.len(), 2);
+        assert_eq!(namespaces[1].name, "Utils");
+    }
+
+    #[test]
+    fn exported_variable() {
+        let (_temp_dir, library_metadata) =
+            setup_test_dir("export const VERSION: string = '1.0.0';");
+        let mut parser = make_parser();
+
+        let tree = parser
+            .parse("export const VERSION: string = '1.0.0';", None)
+            .unwrap();
+        println!(
+            "Variable node structure:\n{}",
+            debug_node(&tree.root_node(), "export const VERSION: string = '1.0.0';")
+        );
+
+        let namespaces = extract_public_api(&library_metadata, &mut parser).unwrap();
+
+        assert_eq!(namespaces.len(), 1);
+        assert_eq!(namespaces[0].symbols.len(), 1);
+        assert_eq!(namespaces[0].symbols[0].name, "VERSION");
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,8 @@
+mod module;
+mod parsing;
+#[cfg(test)]
+mod test_helpers;
+
 use daipendency_extractor::{ExtractionError, LibraryMetadata, Namespace, Symbol};
 use tree_sitter::{Node, Parser};
 
@@ -49,11 +54,9 @@ fn process_node(
                     let mut var_cursor = child.walk();
                     for var_child in child.children(&mut var_cursor) {
                         if var_child.kind() == "variable_declarator" {
-                            let name = get_declaration_name(&var_child, source_code)
-                                .ok_or_else(|| {
-                                    ExtractionError::Malformed(
-                                        "Variable without name".to_string(),
-                                    )
+                            let name =
+                                get_declaration_name(&var_child, source_code).ok_or_else(|| {
+                                    ExtractionError::Malformed("Variable without name".to_string())
                                 })?;
                             namespaces[0].symbols.push(Symbol {
                                 name,
@@ -104,18 +107,9 @@ fn get_node_text(node: Node, source_code: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::test_helpers::make_parser;
     use super::*;
-    use crate::TypeScriptExtractor;
-    use daipendency_extractor::Extractor;
     use daipendency_testing::{debug_node, tempdir::TempDir};
-    use tree_sitter::Parser;
-
-    fn make_parser() -> Parser {
-        let mut parser = Parser::new();
-        let language = TypeScriptExtractor.get_parser_language();
-        parser.set_language(&language).unwrap();
-        parser
-    }
 
     fn setup_test_dir(content: &str) -> (TempDir, LibraryMetadata) {
         let temp_dir = TempDir::new();

--- a/src/api/module.rs
+++ b/src/api/module.rs
@@ -66,7 +66,7 @@ pub enum TypeScriptSymbol {
         jsdoc: Option<String>,
         content: Vec<TypeScriptSymbol>,
         /// Whether the symbol is exported (either when declared, or later in the file).
-        exported: bool,
+        is_exported: bool,
     },
     /// An import from another module (e.g. `import Foo from './foo.js';`).
     ///

--- a/src/api/module.rs
+++ b/src/api/module.rs
@@ -57,7 +57,7 @@ pub enum TypeScriptSymbol {
     /// A symbol (e.g. class, interface, function, constant, type alias).
     Symbol {
         symbol: Symbol,
-        /// Whether the symbol is exported (either when declared, or later in the file).
+        /// Whether the symbol was exported when declared.
         is_exported: bool,
     },
     /// A TypeScript namespace.
@@ -65,7 +65,7 @@ pub enum TypeScriptSymbol {
         name: String,
         jsdoc: Option<String>,
         content: Vec<TypeScriptSymbol>,
-        /// Whether the symbol is exported (either when declared, or later in the file).
+        /// Whether the symbol was exported when declared.
         is_exported: bool,
     },
     /// An import from another module (e.g. `import Foo from './foo.js';`).
@@ -82,7 +82,9 @@ pub enum TypeScriptSymbol {
     /// If a single `export` statement uses multiple types of targets, it will be represented as multiple `ModuleExport` symbols.
     ModuleExport {
         /// The module from which symbols are exported (e.g. `./foo.js` in `export Foo from './foo.js';`).
-        source_module: String,
+        ///
+        /// The source is `None` when the symbol was previously declared or imported in the current file.
+        source_module: Option<String>,
         /// The target of the export (e.g. `Foo` in `export Foo from './foo.js';`).
         target: ExportTarget,
     },

--- a/src/api/module.rs
+++ b/src/api/module.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+
+use daipendency_extractor::Symbol;
+
+/// A TypeScript module (i.e. a file).
+#[derive(Debug, Clone)]
+pub struct Module {
+    pub jsdoc: Option<String>,
+    pub symbols: Vec<TypeScriptSymbol>,
+    pub default_export_name: Option<String>,
+}
+
+/// The target of an import in a TypeScript module.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ImportTarget {
+    /// The default export from another module (e.g. `import React from 'react';`).
+    Default {
+        /// The name of the default export (e.g. `React` in `import React from 'react';`).
+        name: String,
+    },
+    /// A namespace import from another module (e.g. `import * as React from 'react';`).
+    Namespace {
+        /// The name of the namespace (e.g. `React` in `import * as React from 'react';`).
+        name: String,
+    },
+    /// A named import from another module (e.g. `import { useState } from 'react';`).
+    Named {
+        /// The names of the symbols to import (e.g. `useState` in `import { useState } from 'react';`).
+        names: Vec<String>,
+        /// The aliases for the imported symbols (e.g. `useState: foo` in `import { useState as foo } from 'react';`).
+        aliases: HashMap<String, String>,
+    },
+}
+
+/// The target of an export in a TypeScript module.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExportTarget {
+    /// A namespace export from another module (e.g. `export * as React from 'react';`).
+    Namespace {
+        /// The name of the namespace (e.g. `React` in `export * as React from 'react';`).
+        name: String,
+    },
+    /// A named export from another module (e.g. `export { useState } from 'react';`).
+    Named {
+        /// The names of the symbols to export (e.g. `useState` in `export { useState } from 'react';`).
+        names: Vec<String>,
+        /// The aliases for the exported symbols (e.g. `useState: foo` in `export { useState as foo } from 'react';`).
+        aliases: HashMap<String, String>,
+    },
+    /// A barrel export from another module (e.g. `export * from './module.js';`).
+    Barrel,
+}
+
+/// A symbol in a TypeScript module.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypeScriptSymbol {
+    /// A symbol (e.g. class, interface, function, constant, type alias).
+    Symbol {
+        symbol: Symbol,
+        /// Whether the symbol is exported (either when declared, or later in the file).
+        exported: bool,
+    },
+    /// A TypeScript namespace.
+    Namespace {
+        name: String,
+        jsdoc: Option<String>,
+        content: Vec<TypeScriptSymbol>,
+        /// Whether the symbol is exported (either when declared, or later in the file).
+        exported: bool,
+    },
+    /// An import from another module (e.g. `import Foo from './foo.js';`).
+    ///
+    /// If a single `import` statement uses multiple types of targets, it will be represented as multiple `ModuleImport` symbols.
+    ModuleImport {
+        /// The module from which symbols are imported (e.g. `./foo.js` in `import Foo from './foo.js';`).
+        source_module: String,
+        /// The target of the import (e.g. `Foo` in `import Foo from './foo.js';`).
+        target: ImportTarget,
+    },
+    /// An export from another module (e.g. `export Foo from './foo.js';`).
+    ///
+    /// If a single `export` statement uses multiple types of targets, it will be represented as multiple `ModuleExport` symbols.
+    ModuleExport {
+        /// The module from which symbols are exported (e.g. `./foo.js` in `export Foo from './foo.js';`).
+        source_module: String,
+        /// The target of the export (e.g. `Foo` in `export Foo from './foo.js';`).
+        target: ExportTarget,
+    },
+}

--- a/src/api/module.rs
+++ b/src/api/module.rs
@@ -58,7 +58,7 @@ pub enum TypeScriptSymbol {
     Symbol {
         symbol: Symbol,
         /// Whether the symbol is exported (either when declared, or later in the file).
-        exported: bool,
+        is_exported: bool,
     },
     /// A TypeScript namespace.
     Namespace {

--- a/src/api/parsing.rs
+++ b/src/api/parsing.rs
@@ -1,0 +1,911 @@
+use std::collections::HashMap;
+
+use daipendency_extractor::{ExtractionError, Symbol};
+use tree_sitter::{Node, Parser};
+
+use crate::api::module::{ExportTarget, ImportTarget, Module, TypeScriptSymbol};
+
+// TODO: REMOVE WHEN ALL TESTS ARE FIXED
+#[cfg(test)]
+use daipendency_testing::debug_node;
+
+pub fn parse_typescript_file(
+    content: &str,
+    parser: &mut Parser,
+) -> Result<Module, ExtractionError> {
+    let tree = parser
+        .parse(content, None)
+        .ok_or_else(|| ExtractionError::Malformed("Failed to parse source file".to_string()))?;
+    let node = tree.root_node();
+
+    // TODO: REMOVE WHEN ALL TESTS ARE FIXED
+    #[cfg(test)]
+    println!("{}", debug_node(&node, content));
+
+    if node.has_error() {
+        return Err(ExtractionError::Malformed(
+            "Failed to parse source file".to_string(),
+        ));
+    }
+
+    let module_jsdoc = get_module_jsdoc(node, content);
+    let mut module_symbols = vec![];
+    let mut module_exported_names = vec![];
+    let mut default_export_name = None;
+
+    // Extract symbols and track exports
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "export_statement" => {
+                let (symbols, exported, default) = extract_exports(&child, content);
+                module_symbols.extend(symbols);
+                module_exported_names.extend(exported);
+                if default.is_some() {
+                    default_export_name = default;
+                }
+            }
+            "import_statement" => {
+                let symbols = extract_imports(&child, content);
+                module_symbols.extend(symbols);
+            }
+            "ambient_declaration" => {
+                if let Some(symbol) = extract_ambient(&child, content, false) {
+                    module_symbols.push(symbol);
+                }
+            }
+            "expression_statement" => {
+                if let Some(symbol) = extract_namespace(&child, content) {
+                    module_symbols.push(symbol);
+                }
+            }
+            "class_declaration"
+            | "interface_declaration"
+            | "type_alias_declaration"
+            | "enum_declaration" => {
+                let prev_sibling = child.prev_sibling();
+                let jsdoc = prev_sibling
+                    .filter(|n| n.kind() == "comment")
+                    .and_then(|n| n.utf8_text(content.as_bytes()).ok());
+                let source_start = jsdoc
+                    .as_ref()
+                    .map_or(child.start_byte(), |_| prev_sibling.unwrap().start_byte());
+                if let Some(symbol) = extract_symbol(&child, content, source_start) {
+                    module_symbols.push(symbol);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Update exported flag for symbols that are exported
+    for symbol in &mut module_symbols {
+        if let TypeScriptSymbol::Symbol { symbol, exported } = symbol {
+            if module_exported_names.contains(&symbol.name) {
+                *exported = true;
+            }
+        }
+    }
+
+    Ok(Module {
+        jsdoc: module_jsdoc,
+        symbols: module_symbols,
+        default_export_name,
+    })
+}
+
+fn get_jsdoc(node: Option<Node>, content: &str) -> Option<String> {
+    node.filter(|n| n.kind() == "comment")
+        .and_then(|n| n.utf8_text(content.as_bytes()).ok())
+        .filter(|comment| comment.starts_with("/**"))
+        .map(|comment| comment.to_string())
+}
+
+fn get_module_jsdoc<'a>(node: Node<'a>, content: &'a str) -> Option<String> {
+    get_jsdoc(node.child(0), content).and_then(|comment_text| {
+        if comment_text.contains("@file")
+            || comment_text.contains("@fileoverview")
+            || comment_text.contains("@module")
+        {
+            Some(comment_text.to_string())
+        } else {
+            None
+        }
+    })
+}
+
+fn extract_symbol(node: &Node, content: &str, source_start: usize) -> Option<TypeScriptSymbol> {
+    let name = node
+        .child_by_field_name("name")?
+        .utf8_text(content.as_bytes())
+        .ok()?;
+    let source_code = &content[source_start..node.end_byte()];
+    Some(TypeScriptSymbol::Symbol {
+        symbol: Symbol {
+            name: name.to_string(),
+            source_code: source_code.to_string(),
+        },
+        exported: false,
+    })
+}
+
+fn extract_imports(node: &Node, content: &str) -> Vec<TypeScriptSymbol> {
+    let mut cursor = node.walk();
+    let mut children = node.children(&mut cursor);
+    let mut symbols = vec![];
+
+    // Skip "import" keyword
+    if children.next().is_none() {
+        return symbols;
+    }
+
+    // Get import clause
+    let import_clause = match children.next() {
+        Some(clause) => clause,
+        None => return symbols,
+    };
+
+    // Skip "from" keyword
+    if children.next().is_none() {
+        return symbols;
+    }
+
+    // Get source module
+    let source_module = match children
+        .next()
+        .and_then(|n| n.utf8_text(content.as_bytes()).ok())
+        .map(|s| s.trim_matches('\'').to_string())
+    {
+        Some(module) => module,
+        None => return symbols,
+    };
+
+    if import_clause.kind() == "import_clause" {
+        let mut cursor = import_clause.walk();
+        let children = import_clause.children(&mut cursor);
+
+        for child in children {
+            match child.kind() {
+                "identifier" => {
+                    let name = match child.utf8_text(content.as_bytes()).ok() {
+                        Some(name) => name.to_string(),
+                        None => continue,
+                    };
+                    symbols.push(TypeScriptSymbol::ModuleImport {
+                        source_module: source_module.clone(),
+                        target: ImportTarget::Default { name },
+                    });
+                }
+                "namespace_import" => {
+                    let mut cursor = child.walk();
+                    let mut children = child.children(&mut cursor);
+
+                    // Skip "*" and "as" tokens
+                    children.next();
+                    children.next();
+
+                    // Get the name
+                    if let Some(name) = children
+                        .next()
+                        .and_then(|n| n.utf8_text(content.as_bytes()).ok())
+                    {
+                        symbols.push(TypeScriptSymbol::ModuleImport {
+                            source_module: source_module.clone(),
+                            target: ImportTarget::Namespace {
+                                name: name.to_string(),
+                            },
+                        });
+                    }
+                }
+                "named_imports" => {
+                    let mut names = vec![];
+                    let mut cursor = child.walk();
+                    let mut aliases = HashMap::new();
+                    for import_specifier in child.children(&mut cursor) {
+                        if import_specifier.kind() == "import_specifier" {
+                            let mut specifier_cursor = import_specifier.walk();
+                            let mut specifier_children =
+                                import_specifier.children(&mut specifier_cursor);
+                            if let Some(name_node) = specifier_children.next() {
+                                if name_node.kind() == "identifier" {
+                                    if let Ok(name) = name_node.utf8_text(content.as_bytes()) {
+                                        // Check for alias
+                                        if let Some(alias_node) =
+                                            specifier_children.find(|n| n.kind() == "identifier")
+                                        {
+                                            if let Ok(alias) =
+                                                alias_node.utf8_text(content.as_bytes())
+                                            {
+                                                aliases.insert(name.to_string(), alias.to_string());
+                                            }
+                                        }
+                                        names.push(name.to_string());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if !names.is_empty() {
+                        symbols.push(TypeScriptSymbol::ModuleImport {
+                            source_module: source_module.clone(),
+                            target: ImportTarget::Named { names, aliases },
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    symbols
+}
+
+fn extract_exports(
+    node: &Node,
+    content: &str,
+) -> (Vec<TypeScriptSymbol>, Vec<String>, Option<String>) {
+    let mut cursor = node.walk();
+    let mut children = node.children(&mut cursor);
+    let mut symbols = vec![];
+    let mut exported_names = vec![];
+    let mut default_export_name = None;
+
+    // Skip "export" keyword
+    children.next();
+
+    if let Some(first_child) = children.next() {
+        match first_child.kind() {
+            "default" => {
+                // Handle "export default ..."
+                if let Some(next_child) = children.next() {
+                    match next_child.kind() {
+                        "ambient_declaration" => {
+                            if let Some(symbol) = extract_ambient(&next_child, content, true) {
+                                if let TypeScriptSymbol::Symbol { symbol, .. } = &symbol {
+                                    exported_names.push(symbol.name.clone());
+                                    default_export_name = Some(symbol.name.clone());
+                                }
+                                symbols.push(symbol);
+                            }
+                        }
+                        "identifier" => {
+                            if let Ok(name) = next_child.utf8_text(content.as_bytes()) {
+                                exported_names.push(name.to_string());
+                                default_export_name = Some(name.to_string());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            "=" => {
+                // Handle CommonJS export (export = ...)
+                if let Some(next_child) = children.next() {
+                    if next_child.kind() == "identifier" {
+                        if let Ok(name) = next_child.utf8_text(content.as_bytes()) {
+                            exported_names.push(name.to_string());
+                        }
+                    }
+                }
+            }
+            "ambient_declaration" => {
+                if let Some(symbol) = extract_ambient(&first_child, content, true) {
+                    if let TypeScriptSymbol::Symbol { symbol, .. } = &symbol {
+                        exported_names.push(symbol.name.clone());
+                    }
+                    symbols.push(symbol);
+                }
+            }
+            "export_clause" => {
+                let mut specifier_cursor = first_child.walk();
+                let mut names = vec![];
+                let mut aliases = HashMap::new();
+
+                for export_specifier in first_child.children(&mut specifier_cursor) {
+                    if export_specifier.kind() == "export_specifier" {
+                        let mut specifier_cursor = export_specifier.walk();
+                        let mut specifier_children =
+                            export_specifier.children(&mut specifier_cursor);
+                        if let Some(name_node) = specifier_children.next() {
+                            if name_node.kind() == "identifier" {
+                                if let Ok(name) = name_node.utf8_text(content.as_bytes()) {
+                                    names.push(name.to_string());
+
+                                    // Check for alias
+                                    if let Some(alias_node) =
+                                        specifier_children.find(|n| n.kind() == "identifier")
+                                    {
+                                        if let Ok(alias) = alias_node.utf8_text(content.as_bytes())
+                                        {
+                                            aliases.insert(name.to_string(), alias.to_string());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Skip "from" keyword
+                if let Some(from_node) = children.next() {
+                    if from_node.kind() != "from" {
+                        // This is a local export, not a re-export
+                        exported_names.extend(names);
+                    } else {
+                        // Get source module
+                        if let Some(source_module) = children
+                            .next()
+                            .and_then(|n| n.utf8_text(content.as_bytes()).ok())
+                        {
+                            let source_module = source_module.trim_matches('\'').to_string();
+
+                            symbols.push(TypeScriptSymbol::ModuleExport {
+                                source_module,
+                                target: ExportTarget::Named { names, aliases },
+                            });
+                        }
+                    }
+                }
+            }
+            "*" => {
+                // Skip "from" keyword
+                children.next();
+
+                // Get source module
+                if let Some(source_module) = children
+                    .next()
+                    .and_then(|n| n.utf8_text(content.as_bytes()).ok())
+                {
+                    let source_module = source_module.trim_matches('\'').to_string();
+                    symbols.push(TypeScriptSymbol::ModuleExport {
+                        source_module,
+                        target: ExportTarget::Barrel,
+                    });
+                }
+            }
+            "namespace_export" => {
+                let mut cursor = first_child.walk();
+                let mut namespace_children = first_child.children(&mut cursor);
+
+                // Skip "*" token
+                namespace_children.next();
+                // Skip "as" token
+                namespace_children.next();
+
+                // Get the name
+                if let Some(name) = namespace_children
+                    .next()
+                    .and_then(|n| n.utf8_text(content.as_bytes()).ok())
+                {
+                    // Skip "from" keyword
+                    children.next();
+
+                    // Get source module
+                    if let Some(source_module) = children
+                        .next()
+                        .and_then(|n| n.utf8_text(content.as_bytes()).ok())
+                    {
+                        let source_module = source_module.trim_matches('\'').to_string();
+                        symbols.push(TypeScriptSymbol::ModuleExport {
+                            source_module,
+                            target: ExportTarget::Namespace {
+                                name: name.to_string(),
+                            },
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    (symbols, exported_names, default_export_name)
+}
+
+fn extract_ambient(node: &Node, content: &str, exported: bool) -> Option<TypeScriptSymbol> {
+    let declaration = node.child(1)?;
+    let source_start = if exported {
+        // If exported, we need to include the entire export statement
+        node.parent()?.start_byte()
+    } else {
+        // Otherwise, include JSDoc if present
+        get_jsdoc(node.prev_sibling(), content).map_or(node.start_byte(), |_| {
+            node.prev_sibling().unwrap().start_byte()
+        })
+    };
+    let source_end = if exported {
+        // If exported, we need to include the entire export statement
+        node.parent()?.end_byte()
+    } else {
+        node.end_byte()
+    };
+    let source_code = &content[source_start..source_end];
+    match declaration.kind() {
+        "function_signature" => {
+            let name = declaration
+                .child_by_field_name("name")?
+                .utf8_text(content.as_bytes())
+                .ok()?;
+            Some(TypeScriptSymbol::Symbol {
+                symbol: Symbol {
+                    name: name.to_string(),
+                    source_code: source_code.to_string(),
+                },
+                exported,
+            })
+        }
+        "lexical_declaration" => {
+            let variable = declaration.child(1)?;
+            let name = variable
+                .child_by_field_name("name")?
+                .utf8_text(content.as_bytes())
+                .ok()?;
+            Some(TypeScriptSymbol::Symbol {
+                symbol: Symbol {
+                    name: name.to_string(),
+                    source_code: source_code.to_string(),
+                },
+                exported,
+            })
+        }
+        "class_declaration" => {
+            let name = declaration
+                .child_by_field_name("name")?
+                .utf8_text(content.as_bytes())
+                .ok()?;
+            Some(TypeScriptSymbol::Symbol {
+                symbol: Symbol {
+                    name: name.to_string(),
+                    source_code: source_code.to_string(),
+                },
+                exported,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn extract_namespace(node: &Node, content: &str) -> Option<TypeScriptSymbol> {
+    if let Some(internal_module) = node.child(0).filter(|n| n.kind() == "internal_module") {
+        let name = internal_module
+            .child_by_field_name("name")?
+            .utf8_text(content.as_bytes())
+            .ok()?;
+        let statement_block = internal_module.child_by_field_name("body")?;
+        let mut content_symbols = vec![];
+        let mut cursor = statement_block.walk();
+        for child in statement_block.children(&mut cursor) {
+            let kind = child.kind();
+            if let Some(symbol) = match kind {
+                "ambient_declaration" => extract_ambient(&child, content, false),
+                _ => None,
+            } {
+                content_symbols.push(symbol);
+            }
+        }
+
+        Some(TypeScriptSymbol::Namespace {
+            name: name.to_string(),
+            content: content_symbols,
+            exported: false,
+            jsdoc: get_jsdoc(node.prev_sibling(), content),
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::test_helpers::make_parser;
+    use assertables::assert_matches;
+    use daipendency_extractor::ExtractionError;
+
+    #[test]
+    fn empty_file() {
+        let mut parser = make_parser();
+
+        let result = parse_typescript_file("", &mut parser);
+
+        assert_matches!(result, Ok(Module { jsdoc: None, symbols: s, default_export_name: None }) if s.is_empty());
+    }
+
+    #[test]
+    fn malformed_file() {
+        let mut parser = make_parser();
+
+        let result = parse_typescript_file("class {", &mut parser);
+
+        assert_matches!(result, Err(ExtractionError::Malformed(msg)) if msg == "Failed to parse source file");
+    }
+
+    mod module_jsdoc {
+        use super::*;
+
+        const FILE_DESCRIPTION: &str = "Description of the file";
+
+        #[test]
+        fn file_tag() {
+            let mut parser = make_parser();
+            let content = format!("/** @file {FILE_DESCRIPTION} */\ndeclare const foo = 42;");
+
+            let result = parse_typescript_file(&content, &mut parser);
+
+            assert_matches!(result, Ok(Module { jsdoc: Some(j), .. }) if j == format!("/** @file {FILE_DESCRIPTION} */"));
+        }
+
+        #[test]
+        fn fileoverview_tag() {
+            let mut parser = make_parser();
+            let content =
+                format!("/** @fileoverview {FILE_DESCRIPTION} */\ndeclare const foo = 42;");
+
+            let result = parse_typescript_file(&content, &mut parser);
+
+            assert_matches!(result, Ok(Module { jsdoc: Some(j), .. }) if j == format!("/** @fileoverview {FILE_DESCRIPTION} */"));
+        }
+
+        #[test]
+        fn module_tag() {
+            let mut parser = make_parser();
+            let content = format!("/** @module {FILE_DESCRIPTION} */\ndeclare const foo = 42;");
+
+            let result = parse_typescript_file(&content, &mut parser);
+
+            assert_matches!(result, Ok(Module { jsdoc: Some(j), .. }) if j == format!("/** @module {FILE_DESCRIPTION} */"));
+        }
+
+        #[test]
+        fn no_tag() {
+            let mut parser = make_parser();
+            let content = "/** Just a comment */\ndeclare const foo = 42;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { jsdoc: None, .. }));
+        }
+
+        #[test]
+        fn non_jsdoc_block_comment() {
+            let mut parser = make_parser();
+            let content = "/* @module Just a comment */\ndeclare const foo = 42;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { jsdoc: None, .. }));
+        }
+
+        #[test]
+        fn line_comment() {
+            let mut parser = make_parser();
+            let content = "// @module Just a comment\ndeclare const foo = 42;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { jsdoc: None, .. }));
+        }
+    }
+
+    mod symbols {
+        use super::*;
+
+        #[test]
+        fn class_declaration() {
+            let mut parser = make_parser();
+            let content = "declare class Foo { bar(): void; }";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: false } if symbol.name == "Foo" && symbol.source_code == content));
+        }
+
+        #[test]
+        fn type_alias_declaration() {
+            let mut parser = make_parser();
+            let content = "type Bar = string;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: false } if symbol.name == "Bar" && symbol.source_code == content));
+        }
+
+        #[test]
+        fn interface_declaration() {
+            let mut parser = make_parser();
+            let content = "interface Baz { qux: number; }";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: false } if symbol.name == "Baz" && symbol.source_code == content));
+        }
+
+        #[test]
+        fn enum_declaration() {
+            let mut parser = make_parser();
+            let content = "enum Status { Active, Inactive }";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: false } if symbol.name == "Status" && symbol.source_code == content));
+        }
+
+        #[test]
+        fn function_declaration() {
+            let mut parser = make_parser();
+            let content = "declare function greet(name: string): void;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: false } if symbol.name == "greet" && symbol.source_code == content));
+        }
+
+        #[test]
+        fn const_declaration() {
+            let mut parser = make_parser();
+            let content = "declare const VERSION: string;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: false } if symbol.name == "VERSION" && symbol.source_code == content));
+        }
+
+        #[test]
+        fn let_declaration() {
+            let mut parser = make_parser();
+            let content = "declare let counter: number;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: false } if symbol.name == "counter" && symbol.source_code == content));
+        }
+
+        #[test]
+        fn symbol_with_jsdoc() {
+            let mut parser = make_parser();
+            let content = "/** The version number */\ndeclare const VERSION: string;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: false } if symbol.name == "VERSION" && symbol.source_code == content));
+        }
+
+        #[test]
+        fn symbol_without_jsdoc() {
+            let mut parser = make_parser();
+            let content = "declare const VERSION: string;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: false } if symbol.name == "VERSION" && symbol.source_code == content));
+        }
+    }
+
+    mod symbol_exports {
+        use super::*;
+
+        #[test]
+        fn exported_afterwards() {
+            let mut parser = make_parser();
+            let content = "declare const VERSION: string;\nexport { VERSION };";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: true } if symbol.name == "VERSION" && symbol.source_code.contains("declare const VERSION: string")));
+        }
+
+        #[test]
+        fn export_and_declaration() {
+            let mut parser = make_parser();
+            let content = "export declare function greet(name: string): void;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: true } if symbol.name == "greet" && symbol.source_code == content));
+        }
+
+        #[test]
+        fn default_export_and_declaration() {
+            let mut parser = make_parser();
+            let content = "export default declare function greet(name: string): void;";
+
+            let module = parse_typescript_file(content, &mut parser).unwrap();
+
+            assert_matches!(&module, Module { symbols, default_export_name: Some(n), .. } if symbols.len() == 1 && n == "greet");
+            let symbol = &module.symbols[0];
+            assert_matches!(symbol, TypeScriptSymbol::Symbol { symbol, exported: true } if symbol.name == "greet" && symbol.source_code == content);
+        }
+
+        #[test]
+        fn default_export_afterwards() {
+            let mut parser = make_parser();
+            let content = "declare const VERSION: string;\nexport default VERSION;";
+
+            let module = parse_typescript_file(content, &mut parser).unwrap();
+
+            assert_matches!(&module, Module { symbols, default_export_name: Some(n), .. } if symbols.len() == 1 && n == "VERSION");
+            let symbol = &module.symbols[0];
+            assert_matches!(symbol, TypeScriptSymbol::Symbol { symbol, exported: true } if symbol.name == "VERSION" && symbol.source_code.contains("declare const VERSION: string"));
+        }
+
+        #[test]
+        fn commonjs_export() {
+            let mut parser = make_parser();
+            let content = "declare function myFunction(): void;\nexport = myFunction;";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Symbol { symbol, exported: true } if symbol.name == "myFunction" && symbol.source_code.contains("declare function myFunction(): void")));
+        }
+    }
+
+    mod namespaces {
+        use super::*;
+
+        #[test]
+        fn empty_namespace() {
+            let mut parser = make_parser();
+            let content = "namespace Foo {}";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Namespace { name, content, exported: false, jsdoc: None } if name == "Foo" && content.is_empty()));
+        }
+
+        #[test]
+        fn namespace_with_symbol() {
+            let mut parser = make_parser();
+            let content = "namespace Foo { declare const VERSION: string; }";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Namespace { name, content, exported: false, jsdoc: None } if name == "Foo" && content.len() == 1));
+        }
+
+        #[test]
+        fn namespace_with_symbols() {
+            let mut parser = make_parser();
+            let content =
+                "namespace Foo { declare const VERSION: string; declare function greet(): void; }";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Namespace { name, content, jsdoc: None, .. } if name == "Foo" && content.len() == 2));
+        }
+
+        #[test]
+        fn namespace_with_jsdoc() {
+            let mut parser = make_parser();
+            let content =
+                "/** Utility functions */\nnamespace Foo { declare const VERSION: string; }";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Namespace { name, jsdoc: Some(j), .. } if name == "Foo" && j == "/** Utility functions */"));
+        }
+
+        #[test]
+        fn namespace_without_jsdoc() {
+            let mut parser = make_parser();
+            let content = "namespace Foo { declare const VERSION: string; }";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::Namespace { name, jsdoc: None, .. } if name == "Foo"));
+        }
+    }
+
+    mod module_imports {
+        use super::*;
+
+        #[test]
+        fn default_import() {
+            let mut parser = make_parser();
+            let content = "import foo from './foo.js';";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::ModuleImport { source_module, target } if source_module == "./foo.js" && matches!(target, ImportTarget::Default { name } if name == "foo")));
+        }
+
+        #[test]
+        fn namespace_import() {
+            let mut parser = make_parser();
+            let content = "import * as foo from './foo.js';";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::ModuleImport { source_module, target } if source_module == "./foo.js" && matches!(target, ImportTarget::Namespace { name } if name == "foo")));
+        }
+
+        #[test]
+        fn named_import() {
+            let mut parser = make_parser();
+            let content = "import { foo } from './foo.js';";
+            let module = parse_typescript_file(content, &mut parser).unwrap();
+
+            assert_matches!(&module, Module { symbols, .. } if symbols.len() == 1);
+
+            let named_import = &module.symbols[0];
+            assert_matches!(named_import, TypeScriptSymbol::ModuleImport { source_module, .. } if source_module == "./foo.js");
+            assert_matches!(named_import, TypeScriptSymbol::ModuleImport { target, .. } if matches!(target, ImportTarget::Named { names, aliases } if *names == vec!["foo".to_string()] && aliases.is_empty()));
+        }
+
+        #[test]
+        fn named_import_with_alias() {
+            let mut parser = make_parser();
+            let content = "import { foo as bar } from './foo.js';";
+            let module = parse_typescript_file(content, &mut parser).unwrap();
+
+            assert_matches!(&module, Module { symbols, .. } if symbols.len() == 1);
+
+            let named_import = &module.symbols[0];
+            assert_matches!(named_import, TypeScriptSymbol::ModuleImport { source_module, .. } if source_module == "./foo.js");
+            assert_matches!(named_import, TypeScriptSymbol::ModuleImport { target, .. } if matches!(target, ImportTarget::Named { names, aliases } if *names == vec!["foo".to_string()] && aliases == &HashMap::from([("foo".to_string(), "bar".to_string())])));
+        }
+
+        #[test]
+        fn mixed_import() {
+            let mut parser = make_parser();
+            let content = "import foo, { bar } from './foo.js';";
+
+            let module = parse_typescript_file(content, &mut parser).unwrap();
+
+            assert_matches!(&module, Module { symbols, .. } if symbols.len() == 2);
+
+            let default_import = &module.symbols[0];
+            assert_matches!(default_import, TypeScriptSymbol::ModuleImport { source_module, .. } if source_module == "./foo.js");
+            assert_matches!(default_import, TypeScriptSymbol::ModuleImport { target, .. } if matches!(target, ImportTarget::Default { name } if name == "foo"));
+            let named_import = &module.symbols[1];
+            assert_matches!(named_import, TypeScriptSymbol::ModuleImport { source_module, .. } if source_module == "./foo.js");
+            assert_matches!(named_import, TypeScriptSymbol::ModuleImport { target, .. } if matches!(target, ImportTarget::Named { names, aliases } if *names == vec!["bar".to_string()] && aliases.is_empty()));
+        }
+    }
+
+    mod module_exports {
+        use super::*;
+
+        #[test]
+        fn namespace_export() {
+            let mut parser = make_parser();
+            let content = "export * as foo from './foo.js';";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::ModuleExport { source_module, target } if source_module == "./foo.js" && matches!(target, ExportTarget::Namespace { name } if name == "foo")));
+        }
+
+        #[test]
+        fn named_export() {
+            let mut parser = make_parser();
+            let content = "export { foo } from './foo.js';";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::ModuleExport { source_module, target } if source_module == "./foo.js" && matches!(target, ExportTarget::Named { names, aliases } if *names == vec!["foo".to_string()] && aliases.is_empty())));
+        }
+
+        #[test]
+        fn named_with_alias() {
+            let mut parser = make_parser();
+            let content = "export { foo as bar } from './foo.js';";
+
+            let module = parse_typescript_file(content, &mut parser).unwrap();
+
+            assert_matches!(&module, Module { symbols, .. } if symbols.len() == 1);
+            let symbol = &module.symbols[0];
+            assert_matches!(symbol, TypeScriptSymbol::ModuleExport { source_module, .. } if source_module == "./foo.js");
+            assert_matches!(symbol, TypeScriptSymbol::ModuleExport { target, .. } if matches!(target, ExportTarget::Named { names, aliases } if *names == vec!["foo".to_string()] && aliases == &HashMap::from([("foo".to_string(), "bar".to_string())])));
+        }
+
+        #[test]
+        fn barrel_export() {
+            let mut parser = make_parser();
+            let content = "export * from './foo.js';";
+
+            let result = parse_typescript_file(content, &mut parser);
+
+            assert_matches!(result, Ok(Module { symbols: s, .. }) if s.len() == 1 && matches!(&s[0], TypeScriptSymbol::ModuleExport { source_module, target } if source_module == "./foo.js" && matches!(target, ExportTarget::Barrel)));
+        }
+    }
+}

--- a/src/api/test_helpers.rs
+++ b/src/api/test_helpers.rs
@@ -1,12 +1,186 @@
 #![cfg(test)]
 
 use crate::TypeScriptExtractor;
+use assertables::assert_matches;
 use daipendency_extractor::Extractor;
+use std::collections::HashMap;
 use tree_sitter::Parser;
+
+use super::module::{ExportTarget, ImportTarget, TypeScriptSymbol};
 
 pub fn make_parser() -> Parser {
     let mut parser = Parser::new();
     let language = TypeScriptExtractor.get_parser_language();
     parser.set_language(&language).unwrap();
     parser
+}
+
+/// Deconstructs a `TypeScriptSymbol::ModuleImport` into its source module and target.
+pub fn deconstruct_module_import(symbol: &TypeScriptSymbol) -> (String, ImportTarget) {
+    match symbol {
+        TypeScriptSymbol::ModuleImport {
+            source_module,
+            target,
+        } => (source_module.clone(), target.clone()),
+        _ => panic!("Expected module import"),
+    }
+}
+
+/// Deconstructs a `TypeScriptSymbol::Namespace` into its name, content, is_exported and jsdoc.
+pub fn deconstruct_namespace(
+    symbol: &TypeScriptSymbol,
+) -> (String, Vec<TypeScriptSymbol>, bool, Option<String>) {
+    match symbol {
+        TypeScriptSymbol::Namespace {
+            name,
+            content,
+            is_exported,
+            jsdoc,
+        } => (name.clone(), content.clone(), *is_exported, jsdoc.clone()),
+        _ => panic!("Expected namespace"),
+    }
+}
+
+/// Deconstructs a `TypeScriptSymbol::ModuleExport` into its source module and target.
+pub fn deconstruct_module_export(symbol: &TypeScriptSymbol) -> (Option<String>, ExportTarget) {
+    match symbol {
+        TypeScriptSymbol::ModuleExport {
+            source_module,
+            target,
+        } => (source_module.clone(), target.clone()),
+        _ => panic!("Expected module export"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod module_import_deconstruction {
+        use super::*;
+
+        #[test]
+        fn import() {
+            let symbol = TypeScriptSymbol::ModuleImport {
+                source_module: "lodash".to_string(),
+                target: ImportTarget::Default {
+                    name: "lodash".to_string(),
+                },
+            };
+
+            let (module, target) = deconstruct_module_import(&symbol);
+
+            assert_eq!(module, "lodash");
+            assert_eq!(
+                target,
+                ImportTarget::Default {
+                    name: "lodash".to_string()
+                }
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "Expected module import")]
+        fn non_import() {
+            let symbol = TypeScriptSymbol::Symbol {
+                symbol: daipendency_extractor::Symbol {
+                    name: "foo".to_string(),
+                    source_code: "foo".to_string(),
+                },
+                is_exported: false,
+            };
+
+            deconstruct_module_import(&symbol);
+        }
+    }
+
+    mod namespace_deconstruction {
+        use super::*;
+
+        #[test]
+        fn namespace() {
+            let symbol = TypeScriptSymbol::Namespace {
+                name: "Foo".to_string(),
+                content: vec![TypeScriptSymbol::Symbol {
+                    symbol: daipendency_extractor::Symbol {
+                        name: "bar".to_string(),
+                        source_code: "const bar = 42;".to_string(),
+                    },
+                    is_exported: false,
+                }],
+                is_exported: true,
+                jsdoc: Some("/** Utility functions */".to_string()),
+            };
+
+            let (name, content, is_exported, jsdoc) = deconstruct_namespace(&symbol);
+
+            assert_eq!(name, "Foo");
+            assert_eq!(content.len(), 1);
+            assert!(is_exported);
+            assert_eq!(jsdoc, Some("/** Utility functions */".to_string()));
+        }
+
+        #[test]
+        #[should_panic(expected = "Expected namespace")]
+        fn non_namespace() {
+            let symbol = TypeScriptSymbol::Symbol {
+                symbol: daipendency_extractor::Symbol {
+                    name: "foo".to_string(),
+                    source_code: "foo".to_string(),
+                },
+                is_exported: false,
+            };
+
+            deconstruct_namespace(&symbol);
+        }
+    }
+
+    mod module_export_deconstruction {
+        use super::*;
+
+        #[test]
+        fn export_with_source() {
+            let symbol = TypeScriptSymbol::ModuleExport {
+                source_module: Some("lodash".to_string()),
+                target: ExportTarget::Named {
+                    names: vec!["map".to_string()],
+                    aliases: HashMap::new(),
+                },
+            };
+
+            let (source_module, target) = deconstruct_module_export(&symbol);
+
+            assert_eq!(source_module, Some("lodash".to_string()));
+            assert_matches!(target, ExportTarget::Named { names, aliases } if names == vec!["map".to_string()] && aliases.is_empty());
+        }
+
+        #[test]
+        fn export_without_source() {
+            let symbol = TypeScriptSymbol::ModuleExport {
+                source_module: None,
+                target: ExportTarget::Namespace {
+                    name: "utils".to_string(),
+                },
+            };
+
+            let (source_module, target) = deconstruct_module_export(&symbol);
+
+            assert_eq!(source_module, None);
+            assert_matches!(target, ExportTarget::Namespace { name } if name == "utils");
+        }
+
+        #[test]
+        #[should_panic(expected = "Expected module export")]
+        fn non_export() {
+            let symbol = TypeScriptSymbol::Symbol {
+                symbol: daipendency_extractor::Symbol {
+                    name: "foo".to_string(),
+                    source_code: "foo".to_string(),
+                },
+                is_exported: false,
+            };
+
+            deconstruct_module_export(&symbol);
+        }
+    }
 }

--- a/src/api/test_helpers.rs
+++ b/src/api/test_helpers.rs
@@ -1,0 +1,12 @@
+#![cfg(test)]
+
+use crate::TypeScriptExtractor;
+use daipendency_extractor::Extractor;
+use tree_sitter::Parser;
+
+pub fn make_parser() -> Parser {
+    let mut parser = Parser::new();
+    let language = TypeScriptExtractor.get_parser_language();
+    parser.set_language(&language).unwrap();
+    parser
+}

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::{dependencies, metadata};
+use crate::{api, dependencies, metadata};
 use daipendency_extractor::{
     DependencyResolutionError, ExtractionError, Extractor, LibraryMetadata, LibraryMetadataError,
     Namespace,
@@ -26,7 +26,7 @@ impl Extractor for TypeScriptExtractor {
         library_metadata: &LibraryMetadata,
         parser: &mut Parser,
     ) -> Result<Vec<Namespace>, ExtractionError> {
-        todo!()
+        api::extract_public_api(library_metadata, parser)
     }
 
     fn resolve_dependency_path(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod api;
 mod dependencies;
 mod extractor;
 mod metadata;


### PR DESCRIPTION
- [x] Strip function and method implementations.
- [x] Non-exported symbols.
- [x] Symbols `export`ed after declaration.
- [x] Symbols re`export`ed (e.g. `export foo from 'dependency';`).
- [x] Default exports.
- [x] Replace `.unwrap()` use